### PR TITLE
Rgb average

### DIFF
--- a/raster_compare/base/rgb_average.py
+++ b/raster_compare/base/rgb_average.py
@@ -22,5 +22,4 @@ class RgbAverage(object):
     def values(self):
         if self._values is None:
             self._values = np.mean(self.image_bgr, axis=2)
-            self._values[self._values == self.MAX_PIXEL_VALUE] = np.NaN
         return self._values

--- a/raster_compare/rgb_average_overlay.py
+++ b/raster_compare/rgb_average_overlay.py
@@ -59,3 +59,10 @@ if __name__ == '__main__':
     fig.colorbar(img, cax=cax, orientation='horizontal')
     # plt.tight_layout()
     plt.show(**PlotBase.output_defaults())
+
+    a = plt.hist(
+        average_masked.compressed(),
+        bins=np.arange(LOWER_BOUND, RgbAverage.MAX_PIXEL_VALUE + 1, 1)
+    )
+    plt.yscale('log')
+    plt.show()

--- a/raster_compare/rgb_average_overlay.py
+++ b/raster_compare/rgb_average_overlay.py
@@ -20,7 +20,7 @@ parser.add_argument(
     help='Optional raster for axes labels'
 )
 
-COLOR_LIST = ['gold', 'darkorange', 'red', 'brown']
+COLOR_LIST = ['gold', 'darkorange', 'red', 'brown', 'maroon']
 NUM_COLORS = len(COLOR_LIST)
 LOWER_BOUND = 215
 
@@ -33,20 +33,23 @@ if __name__ == '__main__':
     cmap = LinearSegmentedColormap.from_list('gdrb', COLOR_LIST, N=NUM_COLORS)
 
     norm = colors.BoundaryNorm(
-        boundaries=[LOWER_BOUND, 220, 225, 230, 255],
-        ncolors=4
+        boundaries=[LOWER_BOUND, 220, 225, 230, 254, 255],
+        ncolors=NUM_COLORS
     )
 
-    average.values[average.values < LOWER_BOUND] = np.NaN
+    average_masked = np.ma.array(average.values)
+    average_masked.mask = raster.elevation.mask
+
+    average_masked[average_masked < LOWER_BOUND] = np.NaN
 
     fig, (ax1, cax) = plt.subplots(
-        nrows=2, figsize=(6, 5), gridspec_kw={'height_ratios': [1, 0.07]}
+        nrows=2, figsize=(8, 7), gridspec_kw={'height_ratios': [1, 0.07]}
     )
     ax1.imshow(plt.imread(
         arguments.ortho_image), zorder=0, extent=raster.extent
     )
     img = ax1.imshow(
-        average.values,
+        average_masked,
         extent=raster.extent,
         cmap=cmap, norm=norm,
         vmin=LOWER_BOUND, vmax=RgbAverage.MAX_PIXEL_VALUE,


### PR DESCRIPTION
Improve handling for pixel values of 255 and don't treat them as `NaN` on the pixel level. Masking from the elevation values should be used instead. This enables to truly find pixels that are fully saturated (255 average on all channels).