### PR TITLE
Agisoft - Updates and bug fixes

### DIFF
--- a/Agisoft/create_orthomosaic.py
+++ b/Agisoft/create_orthomosaic.py
@@ -34,7 +34,7 @@ class CreateOrthomosaic:
         self.setup_application()
 
         self.project = Metashape.app.document
-        self.project.open(self.project_file)
+        self.project.open(self.project_file.as_posix())
         self.chunk = self.project.chunk
 
     @property


### PR DESCRIPTION
`create_orthomosaic.py`
Call to open the project needs to be a String.